### PR TITLE
fix jbat from crashing and raise buffer size for jurple_console

### DIFF
--- a/src/bat.c
+++ b/src/bat.c
@@ -92,7 +92,6 @@ main (int argc, char **argv)
    	char *powerInfo = getPowerDetails(1);
 
 	if (powerInfo) printf ("%s\n", powerInfo);
-	free(powerInfo);
 	return (0);
 
 

--- a/src/jurple_console.c
+++ b/src/jurple_console.c
@@ -42,7 +42,7 @@ struct AMDeviceNotificationCallbackInformation {
 } ;
 
 
-#define  BUFSIZE 128 // This is used by purpleConsole. So I figure I'll use it too.
+#define  BUFSIZE 1024 // This is used by purpleConsole. So I figure I'll use it too.
 
 void doDeviceConnect(void *deviceHandle)
 {
@@ -108,7 +108,7 @@ void doDeviceConnect(void *deviceHandle)
 
 
 
-	memset (buf, '\0', 128); // technically, buf[0] = '\0' is enough
+	memset (buf, '\0', 1024); // technically, buf[0] = '\0' is enough
 
 	while ((rc = AMDServiceConnectionReceive(f,
 					 buf,


### PR DESCRIPTION
jbat crashes at the end with “free” and jurple_console spits out unreadable characters when the buffer size is 128, raising it fixed that